### PR TITLE
Ignore utf-8 decoding errors

### DIFF
--- a/tail.py
+++ b/tail.py
@@ -247,7 +247,7 @@ class KafkaProd(object):
                             break
 
 def convert(line):
-    udata=line.decode("utf-8")
+    udata=line.decode("utf-8", errors="ignore")
     return udata.encode("ascii","ignore")
 
 if __name__ == '__main__':


### PR DESCRIPTION
This scripts breaks if a different encoding is observed.

Ignoring is the best strategy here as anyways handling would be difficult in downstream.